### PR TITLE
make manifest construction deterministic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "cargo-manifest"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Kornel <kornel@geekhood.net>, Luca Palmieri <rust@lpalmieri.com>"]
 description = "Helper crate to parse and manipulate manifests - `Cargo.toml` files."
 keywords = ["cargo", "metadata", "toml", "serde", "manifest"]
@@ -18,4 +18,4 @@ path = "src/lib.rs"
 [dependencies]
 serde = "1.0.114"
 serde_derive = "1.0.114"
-toml = "0.5.6"
+toml = { version = "0.5.6", features = ["preserve_order"] }

--- a/src/afs.rs
+++ b/src/afs.rs
@@ -1,10 +1,10 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fs::read_dir;
 use std::io;
 use std::path::Path;
 
 pub trait AbstractFilesystem {
-    fn file_names_in(&self, rel_path: &str) -> io::Result<HashSet<Box<str>>>;
+    fn file_names_in(&self, rel_path: &str) -> io::Result<BTreeSet<Box<str>>>;
 }
 
 pub struct Filesystem<'a> {
@@ -18,7 +18,7 @@ impl<'a> Filesystem<'a> {
 }
 
 impl<'a> AbstractFilesystem for Filesystem<'a> {
-    fn file_names_in(&self, rel_path: &str) -> io::Result<HashSet<Box<str>>> {
+    fn file_names_in(&self, rel_path: &str) -> io::Result<BTreeSet<Box<str>>> {
         Ok(read_dir(self.path.join(rel_path))?
             .filter_map(|entry| {
                 entry


### PR DESCRIPTION
Make manifest construction deterministic.

The use of a `HashSet` when traversing directories was causing non-determinism when constructing the autobins and autotests. It has been switched for a `BtreeSet`.

I also enabled the `preserve_order` feature for the `toml` crate. Not sure if this is strictly necessary but it seemed a good idea.