### PR TITLE
Add support for boolean values in package.readme

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,7 +475,7 @@ pub struct Package<Metadata = Value> {
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     /// This points to a file under the package root (relative to this `Cargo.toml`).
-    pub readme: Option<String>,
+    pub readme: Option<StringOrBool>,
     #[serde(default)]
     pub keywords: Vec<String>,
     #[serde(default)]
@@ -499,6 +499,13 @@ pub struct Package<Metadata = Value> {
     pub autobenches: bool,
     #[serde(default)]
     pub publish: Publish,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(untagged)]
+pub enum StringOrBool {
+    String(String),
+    Bool(bool),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -74,6 +74,22 @@ fn metadata() {
 }
 
 #[test]
+fn readme() {
+    let base = "[package]\nname = \"foo\"\nversion = \"1\"";
+
+    let m = Manifest::from_str(&format!("{}\nreadme = \"hello.md\"", base)).unwrap();
+    let readme = m.package.unwrap().readme.unwrap();
+    assert_eq!(lib::StringOrBool::String("hello.md".to_string()), readme);
+
+    let m = Manifest::from_str(&format!("{}\nreadme = true", base)).unwrap();
+    let readme = m.package.unwrap().readme.unwrap();
+    assert_eq!(lib::StringOrBool::Bool(true), readme);
+
+    let m = Manifest::from_str(&format!("{}\nreadme = 1", base));
+    assert!(m.is_err());
+}
+
+#[test]
 fn legacy() {
     let m = Manifest::from_slice(
         br#"[project]


### PR DESCRIPTION
[`package.readme`][1] supports boolean values for suppressing the default `README` file lookup with `readme = false`, or defaulting to `README.md` with `readme = true`.

I've pretty much copied the implemention [from cargo itself][2], but with a derived `Deserialize` since the improved error message is probably not worth the manual impl.

Please let me know if you have any feedback! Thanks.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-readme-field
[2]: https://github.com/rust-lang/cargo/blob/c524fa4e36b1b6134bf6d1fc17f0648f194118c7/src/cargo/util/toml/mod.rs#L715-L720

---

**Context:** I'm using `cargo-chef` as part of a workflow for cross-platform testing, and `cargo chef prepare` is failing with an error:

```
Error: Failed to compute recipe

Caused by:
    0: invalid type: boolean `true`, expected a string for key `package.readme` at line 10 column 10
    1: invalid type: boolean `true`, expected a string for key `package.readme` at line 10 column 10
```