### PR TITLE
Lint tests in CI

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --tests -- -D warnings
 
   coverage:
     name: Code coverage

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -2,7 +2,6 @@ use cargo_manifest as lib;
 use cargo_manifest::Manifest;
 use std::fs::read;
 use std::str::FromStr;
-use toml;
 
 #[test]
 fn own() {
@@ -46,10 +45,7 @@ fn autobin() {
     assert!(package.autobins);
     assert!(m.lib.is_none());
     assert_eq!(1, m.bin.as_ref().unwrap().len());
-    assert_eq!(
-        Some("auto-bin"),
-        m.bin.unwrap()[0].name.as_ref().map(|s| s.as_str())
-    );
+    assert_eq!(Some("auto-bin"), m.bin.unwrap()[0].name.as_deref());
 }
 
 #[test]


### PR DESCRIPTION
I have my editor set up to do this and noticed a couple of warnings while making #6. I figured I might as well turn on linting for tests in CI, in case it's something you think should be enabled! Thanks.