### PR TITLE
Autodetect also build = "build.rs" field of [package]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
             }
 
             if package.autobins && self.bin.is_none() {
-                let mut bin = self.autoset("src/bin", &fs);
+                let mut bin = autoset(package, "src/bin", &fs);
                 if src.contains("main.rs") {
                     bin.push(Product {
                         name: Some(package.name.clone()),
@@ -199,46 +199,44 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
                 self.bin = Some(bin);
             }
             if package.autoexamples && self.example.is_none() {
-                self.example = Some(self.autoset("examples", &fs));
+                self.example = Some(autoset(package, "examples", &fs));
             }
             if package.autotests && self.test.is_none() {
-                self.test = Some(self.autoset("tests", &fs));
+                self.test = Some(autoset(package, "tests", &fs));
             }
             if package.autobenches && self.bench.is_none() {
-                self.bench = Some(self.autoset("benches", &fs));
+                self.bench = Some(autoset(package, "benches", &fs));
             }
         }
         Ok(())
     }
+}
 
-    fn autoset(&self, dir: &str, fs: &dyn AbstractFilesystem) -> Vec<Product> {
-        let mut out = Vec::new();
-        if let Some(ref package) = self.package {
-            if let Ok(bins) = fs.file_names_in(dir) {
-                for name in bins {
-                    let rel_path = format!("{}/{}", dir, name);
-                    if name.ends_with(".rs") {
-                        out.push(Product {
-                            name: Some(name.trim_end_matches(".rs").into()),
-                            path: Some(rel_path),
-                            edition: Some(package.edition),
-                            ..Product::default()
-                        })
-                    } else if let Ok(sub) = fs.file_names_in(&rel_path) {
-                        if sub.contains("main.rs") {
-                            out.push(Product {
-                                name: Some(name.into()),
-                                path: Some(rel_path + "/main.rs"),
-                                edition: Some(package.edition),
-                                ..Product::default()
-                            })
-                        }
-                    }
+fn autoset<T>(package: &Package<T>, dir: &str, fs: &dyn AbstractFilesystem) -> Vec<Product> {
+    let mut out = Vec::new();
+    if let Ok(bins) = fs.file_names_in(dir) {
+        for name in bins {
+            let rel_path = format!("{}/{}", dir, name);
+            if name.ends_with(".rs") {
+                out.push(Product {
+                    name: Some(name.trim_end_matches(".rs").into()),
+                    path: Some(rel_path),
+                    edition: Some(package.edition),
+                    ..Product::default()
+                })
+            } else if let Ok(sub) = fs.file_names_in(&rel_path) {
+                if sub.contains("main.rs") {
+                    out.push(Product {
+                        name: Some(name.into()),
+                        path: Some(rel_path + "/main.rs"),
+                        edition: Some(package.edition),
+                        ..Product::default()
+                    })
                 }
             }
         }
-        out
     }
+    out
 }
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]

--- a/tests/autobuild/Cargo.toml
+++ b/tests/autobuild/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "buildrstest"
+version = "0.2.0"

--- a/tests/metadata/Cargo.toml
+++ b/tests/metadata/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "metadata"
 version = "0.1.0"
+build = "foobar.rs"
 
 [lib]
 path = "lib.rs"

--- a/tests/metadata/build.rs
+++ b/tests/metadata/build.rs
@@ -1,0 +1,2 @@
+// Presence of this files ensures that `metadata` test checks that explicit `build` key in
+// Cargo.toml has precedence over auto-detected build.rs file.

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -67,10 +67,18 @@ fn autolib() {
 }
 
 #[test]
+fn autobuild() {
+    let m = Manifest::from_path("tests/autobuild/Cargo.toml").expect("load autobuild");
+    let package = m.package.as_ref().unwrap();
+    assert_eq!(Some(lib::Value::String("build.rs".into())), package.build);
+}
+
+#[test]
 fn metadata() {
     let m = Manifest::from_path("tests/metadata/Cargo.toml").expect("load metadata");
     let package = m.package.as_ref().unwrap();
     assert_eq!("metadata", package.name);
+    assert_eq!(Some(lib::Value::String("foobar.rs".into())), package.build);
 }
 
 #[test]


### PR DESCRIPTION
With this, support for `build.rs` in `cargo chef` should be complete.

See LukeMathWalker/cargo-chef#44

---

#### Make autoset() a free-standing function taking &Package

This is required to prevent borrow checking errors in the next commit,
and I argue it is more logical this way - it no longer has to check that
self.package is Option::Some for example.