### PR TITLE
Allow unnecessary wrap for deserialize_with fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -558,6 +558,7 @@ fn default_master() -> String {
     "master".to_string()
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn ok_or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
 where
     T: Deserialize<'de> + Default,


### PR DESCRIPTION
This fixes the current clippy error.