### PR TITLE
[Breaking] Refine serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "cargo-manifest"
 version = "0.2.8"
 authors = ["Kornel <kornel@geekhood.net>, Luca Palmieri <rust@lpalmieri.com>"]
@@ -16,6 +16,5 @@ name = "cargo_manifest"
 path = "src/lib.rs"
 
 [dependencies]
-serde = "1.0.114"
-serde_derive = "1.0.114"
+serde = { version = "1.0.114", features = ["derive"] }
 toml = { version = "0.5.6", features = ["preserve_order"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,7 @@ impl Dependency {
     pub fn req_features(&self) -> &[String] {
         match *self {
             Dependency::Simple(_) => &[],
-            Dependency::Detailed(ref d) => d.features.as_ref().map(|v| v.as_slice()).unwrap_or(&[]),
+            Dependency::Detailed(ref d) => d.features.as_deref().unwrap_or(&[]),
         }
     }
 


### PR DESCRIPTION
Mark all fields in `DependencyDetail` as optional.
Ensure that table serialization works as expected by serializing tables last.