### PR TITLE
Bump toml version for forced indexmap std flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["derive"] }
-toml = { version = "0.5.6", features = ["preserve_order"] }
+toml = { version = "0.7.3", features = ["preserve_order"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,7 @@ use std::io;
 pub enum Error {
     Parse(toml::de::Error),
     Io(io::Error),
+    Utf8(std::str::Utf8Error),
 }
 
 impl StdErr for Error {
@@ -13,6 +14,7 @@ impl StdErr for Error {
         match *self {
             Error::Parse(ref err) => Some(err),
             Error::Io(ref err) => Some(err),
+            Error::Utf8(ref err) => Some(err),
         }
     }
 }
@@ -22,6 +24,7 @@ impl fmt::Display for Error {
         match *self {
             Error::Parse(ref err) => err.fmt(f),
             Error::Io(ref err) => err.fmt(f),
+            Error::Utf8(ref err) => err.fmt(f),
         }
     }
 }
@@ -31,6 +34,7 @@ impl Clone for Error {
         match *self {
             Error::Parse(ref err) => Error::Parse(err.clone()),
             Error::Io(ref err) => Error::Io(io::Error::new(err.kind(), err.to_string())),
+            Error::Utf8(ref err) => Error::Utf8(err.clone()),
         }
     }
 }
@@ -44,5 +48,11 @@ impl From<toml::de::Error> for Error {
 impl From<io::Error> for Error {
     fn from(o: io::Error) -> Self {
         Error::Io(o)
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(o: std::str::Utf8Error) -> Self {
+        Error::Utf8(o)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

`indexmap` relies on `autocfg` for `std` detection but this breaks on some systems -- it's been updated to force `std` on, and `toml` has been updated to use it, but `cargo-manifest` still relies on an old version which doesn't specify the flag.

*Description of changes:*

This updates the `toml` dep.

There were a few changes - `from_slice` is gone (worked around by parsing string first), the "final dict" thing was apparently removed due to being unnecessary (I don't know if this is case, but I updated this accordingly).  It compiles, but I'm not entirely sure what use cases would be affected by the changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
