### PR TITLE
Copy strip settings from upstream

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     Parse(toml::de::Error),
     Io(io::Error),
     Utf8(std::str::Utf8Error),
-    Other(&'static str),
+    Other(String),
 }
 
 impl StdErr for Error {
@@ -23,7 +23,7 @@ impl StdErr for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
+        match self {
             Error::Parse(ref err) => err.fmt(f),
             Error::Io(ref err) => err.fmt(f),
             Error::Utf8(ref err) => err.fmt(f),
@@ -34,11 +34,11 @@ impl fmt::Display for Error {
 
 impl Clone for Error {
     fn clone(&self) -> Self {
-        match *self {
+        match self {
             Error::Parse(ref err) => Error::Parse(err.clone()),
             Error::Io(ref err) => Error::Io(io::Error::new(err.kind(), err.to_string())),
             Error::Utf8(ref err) => Error::Utf8(*err),
-            Error::Other(msg) => Error::Other(msg),
+            Error::Other(msg) => Error::Other(msg.clone()),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     Parse(toml::de::Error),
     Io(io::Error),
     Utf8(std::str::Utf8Error),
+    Other(&'static str),
 }
 
 impl StdErr for Error {
@@ -15,6 +16,7 @@ impl StdErr for Error {
             Error::Parse(ref err) => Some(err),
             Error::Io(ref err) => Some(err),
             Error::Utf8(ref err) => Some(err),
+            Error::Other(_) => None,
         }
     }
 }
@@ -25,6 +27,7 @@ impl fmt::Display for Error {
             Error::Parse(ref err) => err.fmt(f),
             Error::Io(ref err) => err.fmt(f),
             Error::Utf8(ref err) => err.fmt(f),
+            Error::Other(msg) => f.write_str(msg),
         }
     }
 }
@@ -35,6 +38,7 @@ impl Clone for Error {
             Error::Parse(ref err) => Error::Parse(err.clone()),
             Error::Io(ref err) => Error::Io(io::Error::new(err.kind(), err.to_string())),
             Error::Utf8(ref err) => Error::Utf8(*err),
+            Error::Other(msg) => Error::Other(msg),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,9 +364,17 @@ impl TryFrom<Value> for StripSetting {
                 "none" => Self::None,
                 "debuginfo" => Self::Debuginfo,
                 "symbols" => Self::Symbols,
-                _ => return Err(Error::Other("strip setting has unknown string value")),
+                other => {
+                    return Err(Error::Other(format!(
+                        "'{other}' is not a valid value for 'strip'"
+                    )))
+                }
             },
-            _ => return Err(Error::Other("wrong data type for strip setting")),
+            _ => {
+                return Err(Error::Other(
+                    "wrong data type for strip setting".to_string(),
+                ))
+            }
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,49 @@ pub struct Profiles {
     pub custom: BTreeMap<String, Profile>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(try_from = "toml::Value")]
+pub enum StripSetting {
+    /// false
+    None,
+    Debuginfo,
+    /// true
+    Symbols,
+}
+
+impl Serialize for StripSetting {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::None => serializer.serialize_bool(false),
+            Self::Debuginfo => serializer.serialize_str("debuginfo"),
+            Self::Symbols => serializer.serialize_bool(true),
+        }
+    }
+}
+
+impl TryFrom<Value> for StripSetting {
+    type Error = Error;
+
+    fn try_from(v: Value) -> Result<Self, Error> {
+        Ok(match v {
+            Value::Boolean(b) => {
+                if b {
+                    Self::Symbols
+                } else {
+                    Self::None
+                }
+            }
+            Value::String(s) => match s.as_str() {
+                "none" => Self::None,
+                "debuginfo" => Self::Debuginfo,
+                "symbols" => Self::Symbols,
+                _ => return Err(Error::Other("strip setting has unknown string value")),
+            },
+            _ => return Err(Error::Other("wrong data type for strip setting")),
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Profile {
@@ -345,6 +388,7 @@ pub struct Profile {
     pub incremental: Option<bool>,
     #[serde(alias = "overflow_checks")]
     pub overflow_checks: Option<bool>,
+    pub strip: Option<StripSetting>,
     #[serde(default)]
     pub package: BTreeMap<String, Value>,
     /// profile overrides


### PR DESCRIPTION
This copies support for the `strip` parameter of profiles from upstream, to fix https://github.com/LukeMathWalker/cargo-chef/issues/149. I rebuilt cargo-chef with this change, and confirmed that it fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
