### PR TITLE
MaybeInherited: Implement `as_ref()` and `local()` fns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,7 +620,7 @@ impl<T> MaybeInherited<T> {
         Self::Inherited { workspace: True }
     }
 
-    pub fn local(self) -> Option<T> {
+    pub fn as_local(self) -> Option<T> {
         match self {
             Self::Local(x) => Some(x),
             Self::Inherited { .. } => None,


### PR DESCRIPTION
These functions roughly match the `as_ref()` and `ok()` functions of the built-in `Result` type, or the equivalents on the `Option` type. The purpose of these changes is to make accessing the data inside the `Local` variant a little more ergonomic.

Their combination is especially useful as e.g.`foo.as_ref().local()` returns `Option<&T>` which only borrows instead of moving the data.

A future PR could potentially add e.g. `fn version(&self) -> MaybeInherited<&str> { self.version.as_ref() }` to simplify things even further.

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
