### PR TITLE
Change `build` field to `Option<StringOrBool>`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,12 +273,12 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
                 self.bench = Some(autoset(package, "benches", &fs));
             }
 
-            if package.build.is_none()
+            if matches!(package.build, None | Some(StringOrBool::Bool(true)))
                 && fs
                     .file_names_in(".")
                     .map_or(false, |dir| dir.contains("build.rs"))
             {
-                package.build = Some(Value::String("build.rs".to_string()));
+                package.build = Some(StringOrBool::String("build.rs".to_string()));
             }
         }
         Ok(())
@@ -676,7 +676,7 @@ pub struct Package<Metadata = Value> {
     /// e.g. "1.9.0"
     pub version: MaybeInherited<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub build: Option<Value>,
+    pub build: Option<StringOrBool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub workspace: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -87,7 +87,10 @@ fn autolib() {
 fn autobuild() {
     let m = Manifest::from_path("tests/autobuild/Cargo.toml").expect("load autobuild");
     let package = m.package.as_ref().unwrap();
-    assert_eq!(Some(lib::Value::String("build.rs".into())), package.build);
+    assert_eq!(
+        Some(lib::StringOrBool::String("build.rs".into())),
+        package.build
+    );
 }
 
 #[test]
@@ -95,7 +98,10 @@ fn metadata() {
     let m = Manifest::from_path("tests/metadata/Cargo.toml").expect("load metadata");
     let package = m.package.as_ref().unwrap();
     assert_eq!("metadata", package.name);
-    assert_eq!(Some(lib::Value::String("foobar.rs".into())), package.build);
+    assert_eq!(
+        Some(lib::StringOrBool::String("foobar.rs".into())),
+        package.build
+    );
 }
 
 #[test]


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-build-field says that valid values for the `build` field are paths and `false`, which basically matches the `readme` field (except for the workspace inheritance). Since `readme` uses the `StringOrBool` enum, it makes sense to use the same for the `build` field as well.

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
