### PR TITLE
Add split-debuginfo to cargo profiles

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,7 @@ pub struct Profile {
     pub strip: Option<StripSetting>,
     #[serde(default)]
     pub package: BTreeMap<String, Value>,
+    pub split_debuginfo: Option<String>,
     /// profile overrides
     pub build_override: Option<Value>,
 }

--- a/tests/opt_level.toml
+++ b/tests/opt_level.toml
@@ -16,6 +16,7 @@ publish = false
 
 [profile.bench]
 opt-level = 3
+split-debuginfo = "unpacked"
 
 [profile.my-custom]
 opt-level = 2

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -28,6 +28,7 @@ fn opt_level() {
         3,
         profiles
             .bench
+            .clone()
             .unwrap()
             .opt_level
             .unwrap()
@@ -49,6 +50,15 @@ fn opt_level() {
     assert!(!m.lib.unwrap().bench);
     assert_eq!(None, package.edition);
     assert_eq!(1, m.patch.unwrap().len());
+    assert_eq!(
+        "unpacked",
+        profiles
+            .bench
+            .unwrap()
+            .split_debuginfo
+            .unwrap()
+            .as_str()
+    );
 }
 
 #[test]


### PR DESCRIPTION
*Issue #, if available:* relevant issue in [cargo chef](https://github.com/LukeMathWalker/cargo-chef/issues/236)

*Description of changes:*

Added split-debuginfo to profiles.

I did not add `#[serde(alias = "split_debuginfo")]`. When I tried that with a `Cargo.toml`, it issued a warning about unused key. However, it issued the same warning for `overflow_checks` which have this alias. So I am not sure if even though there is the warning the alias are actually parsed or not. I'm saying this just in case the new field should have this attribute.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
