### PR TITLE
Package: Fix `default-run` naming

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -720,6 +720,7 @@ pub struct Package<Metadata = Value> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include: Option<MaybeInherited<Vec<String>>>,
 
+    #[serde(rename = "default-run")]
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The default binary to run by cargo run.
     pub default_run: Option<String>,


### PR DESCRIPTION
see https://github.com/rust-lang/cargo/blob/b4ddf95ad9954118ac0dae835f2966394ad04c02/src/cargo/util/toml/mod.rs#L1400 and https://github.com/rust-lang/cargo/blob/b4ddf95ad9954118ac0dae835f2966394ad04c02/src/cargo/util/toml/mod.rs#L1424


<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
