### PR TITLE
Make `Manifest` and `Package` easier to instantiate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,6 +767,40 @@ pub struct Package<Metadata = Value> {
     pub resolver: Option<Resolver>,
 }
 
+impl<Metadata> Package<Metadata> {
+    pub fn new(name: String, version: String) -> Self {
+        Self {
+            name,
+            edition: None,
+            version: MaybeInherited::Local(version),
+            build: None,
+            workspace: None,
+            authors: None,
+            links: None,
+            description: None,
+            homepage: None,
+            documentation: None,
+            readme: None,
+            keywords: None,
+            categories: None,
+            license: None,
+            license_file: None,
+            repository: None,
+            metadata: None,
+            rust_version: None,
+            exclude: None,
+            include: None,
+            default_run: None,
+            autobins: true,
+            autoexamples: true,
+            autotests: true,
+            autobenches: true,
+            publish: None,
+            resolver: None,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum StringOrBool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,30 @@ pub struct Manifest<Metadata = Value> {
     pub badges: Option<Badges>,
 }
 
+impl<Metadata> Default for Manifest<Metadata> {
+    #[allow(deprecated)]
+    fn default() -> Self {
+        Self {
+            package: None,
+            cargo_features: None,
+            workspace: None,
+            dependencies: None,
+            dev_dependencies: None,
+            build_dependencies: None,
+            target: None,
+            features: None,
+            patch: None,
+            lib: None,
+            profile: None,
+            badges: None,
+            bin: None,
+            bench: None,
+            test: None,
+            example: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct Workspace {

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -1,0 +1,15 @@
+use cargo_manifest::{Manifest, Package};
+
+#[test]
+fn basic() {
+    let manifest = Manifest {
+        package: Some(Package::<()>::new("foo".into(), "1.0.0".into())),
+        ..Default::default()
+    };
+
+    let serialized = toml::to_string(&manifest).unwrap();
+    assert_eq!(
+        serialized,
+        "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n"
+    );
+}


### PR DESCRIPTION
`Manifest` and `Package` are currently quite annoying to instantiate because all the fields need to be explicitly assigned even if only a small subset is used.

This PR implements the `Default` trait for the `Manifest` struct allowing an instantiation like `Manifest { package, ..Default::default() }`.

This PR also adds a `new()` fn to the `Package` struct for similar reasons. An alternative to this is implementing `Default` too, but that would leave us with `name: ""` and `version: ""`. I'm undecided which way feels better, but for `new()` there is [prior art](https://docs.rs/cargo_toml/0.16.0/cargo_toml/struct.Package.html#method.new).

Finally, this PR also adds a small serialization test case, to ensure that these API keep working in the future :)

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
