### PR TITLE
Dependency: Add `Inherited` variant

### DIFF
--- a/tests/snapshots/parse__default_features_casing.snap
+++ b/tests/snapshots/parse__default_features_casing.snap
@@ -58,7 +58,6 @@ Manifest {
                         ],
                     ),
                     optional: None,
-                    workspace: None,
                     default_features: Some(
                         false,
                     ),

--- a/tests/snapshots/parse__opt_level.snap
+++ b/tests/snapshots/parse__opt_level.snap
@@ -110,7 +110,6 @@ Manifest {
                     rev: None,
                     features: None,
                     optional: None,
-                    workspace: None,
                     default_features: Some(
                         false,
                     ),
@@ -131,7 +130,6 @@ Manifest {
                     rev: None,
                     features: None,
                     optional: None,
-                    workspace: None,
                     default_features: None,
                     package: None,
                 },
@@ -168,7 +166,6 @@ Manifest {
                         rev: None,
                         features: None,
                         optional: None,
-                        workspace: None,
                         default_features: Some(
                             false,
                         ),

--- a/tests/snapshots/parse__workspace_dependency-2.snap
+++ b/tests/snapshots/parse__workspace_dependency-2.snap
@@ -40,49 +40,25 @@ Manifest {
     workspace: None,
     dependencies: Some(
         {
-            "chrono": Detailed(
-                DependencyDetail {
-                    version: None,
-                    registry: None,
-                    registry_index: None,
-                    path: None,
-                    git: None,
-                    branch: None,
-                    tag: None,
-                    rev: None,
+            "chrono": Inherited(
+                InheritedDependencyDetail {
+                    workspace: True,
                     features: None,
                     optional: None,
-                    workspace: Some(
-                        true,
-                    ),
-                    default_features: None,
-                    package: None,
                 },
             ),
             "config": Simple(
                 "0.13",
             ),
-            "tokio": Detailed(
-                DependencyDetail {
-                    version: None,
-                    registry: None,
-                    registry_index: None,
-                    path: None,
-                    git: None,
-                    branch: None,
-                    tag: None,
-                    rev: None,
+            "tokio": Inherited(
+                InheritedDependencyDetail {
+                    workspace: True,
                     features: Some(
                         [
                             "rt-multi-thread",
                         ],
                     ),
                     optional: None,
-                    workspace: Some(
-                        true,
-                    ),
-                    default_features: None,
-                    package: None,
                 },
             ),
         },

--- a/tests/snapshots/parse__workspace_dependency.snap
+++ b/tests/snapshots/parse__workspace_dependency.snap
@@ -36,7 +36,6 @@ Manifest {
                                 ],
                             ),
                             optional: None,
-                            workspace: None,
                             default_features: None,
                             package: None,
                         },


### PR DESCRIPTION
`DependencyDetail` can have quite a few other fields, while with inheritance only `features` and `optional` are allowed (see https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace). Instead of having `Detailed` represent both cases, this change introduces a new `Inherited` variant specifically for the `{ workspace = true }` case.

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
