### PR TITLE
Use `thiserror` crate to derive `Error` impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1.0.114", features = ["derive"] }
+thiserror = "1.0.49"
 toml = { version = "0.7.3", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,35 +1,15 @@
-use std::error::Error as StdErr;
-use std::fmt;
 use std::io;
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    Parse(toml::de::Error),
-    Io(io::Error),
-    Utf8(std::str::Utf8Error),
+    #[error(transparent)]
+    Parse(#[from] toml::de::Error),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+    #[error(transparent)]
+    Utf8(#[from] std::str::Utf8Error),
+    #[error("{0}")]
     Other(String),
-}
-
-impl StdErr for Error {
-    fn source(&self) -> Option<&(dyn StdErr + 'static)> {
-        match *self {
-            Error::Parse(ref err) => Some(err),
-            Error::Io(ref err) => Some(err),
-            Error::Utf8(ref err) => Some(err),
-            Error::Other(_) => None,
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Parse(ref err) => err.fmt(f),
-            Error::Io(ref err) => err.fmt(f),
-            Error::Utf8(ref err) => err.fmt(f),
-            Error::Other(msg) => f.write_str(msg),
-        }
-    }
 }
 
 impl Clone for Error {
@@ -40,23 +20,5 @@ impl Clone for Error {
             Error::Utf8(ref err) => Error::Utf8(*err),
             Error::Other(msg) => Error::Other(msg.clone()),
         }
-    }
-}
-
-impl From<toml::de::Error> for Error {
-    fn from(o: toml::de::Error) -> Self {
-        Error::Parse(o)
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(o: io::Error) -> Self {
-        Error::Io(o)
-    }
-}
-
-impl From<std::str::Utf8Error> for Error {
-    fn from(o: std::str::Utf8Error) -> Self {
-        Error::Utf8(o)
     }
 }


### PR DESCRIPTION
The https://github.com/dtolnay/thiserror crate basically generates the same code, but requires much less boilerplate compared to implementing these impls manually. The downside would be that we're adding another dependency and potentially a small increase in compile time, but on the other hand it makes it much easier to add new custom error variants.

<sub>By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.</sub>
