### PR TITLE
Package version can now be optional

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,7 +771,8 @@ pub struct Package<Metadata = Value> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub edition: Option<MaybeInherited<Edition>>,
     /// e.g. "1.9.0"
-    pub version: MaybeInherited<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<MaybeInherited<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub build: Option<StringOrBool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -840,7 +841,7 @@ impl<Metadata> Package<Metadata> {
         Self {
             name,
             edition: None,
-            version: MaybeInherited::Local(version),
+            version: Some(MaybeInherited::Local(version)),
             build: None,
             workspace: None,
             authors: None,

--- a/tests/opt_version.toml
+++ b/tests/opt_version.toml
@@ -1,0 +1,5 @@
+[package]
+name = "opt_version"
+
+[lib]
+path = "lib.rs"

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -25,6 +25,12 @@ fn opt_level() {
 }
 
 #[test]
+fn opt_version() {
+    let m = Manifest::from_path("tests/opt_version.toml").expect("load metadata");
+    insta::assert_debug_snapshot!(m);
+}
+
+#[test]
 fn autobin() {
     let m = Manifest::from_path("tests/autobin/Cargo.toml").expect("load autobin");
     insta::assert_debug_snapshot!(m);

--- a/tests/snapshots/parse__autobin.snap
+++ b/tests/snapshots/parse__autobin.snap
@@ -11,8 +11,10 @@ Manifest {
                     E2018,
                 ),
             ),
-            version: Local(
-                "0.1.0",
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__autobuild.snap
+++ b/tests/snapshots/parse__autobuild.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "buildrstest",
             edition: None,
-            version: Local(
-                "0.2.0",
+            version: Some(
+                Local(
+                    "0.2.0",
+                ),
             ),
             build: Some(
                 String(

--- a/tests/snapshots/parse__autolib.snap
+++ b/tests/snapshots/parse__autolib.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "auto-lib",
             edition: None,
-            version: Local(
-                "0.1.0",
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__default_features_casing.snap
+++ b/tests/snapshots/parse__default_features_casing.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__dev_dependencies_casing.snap
+++ b/tests/snapshots/parse__dev_dependencies_casing.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__legacy-2.snap
+++ b/tests/snapshots/parse__legacy-2.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__legacy.snap
+++ b/tests/snapshots/parse__legacy.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__metadata.snap
+++ b/tests/snapshots/parse__metadata.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "metadata",
             edition: None,
-            version: Local(
-                "0.1.0",
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
             ),
             build: Some(
                 String(

--- a/tests/snapshots/parse__opt_level.snap
+++ b/tests/snapshots/parse__opt_level.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "byteorder",
             edition: None,
-            version: Local(
-                "1.2.3",
+            version: Some(
+                Local(
+                    "1.2.3",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__opt_version.snap
+++ b/tests/snapshots/parse__opt_version.snap
@@ -1,17 +1,14 @@
 ---
 source: tests/parse.rs
+assertion_line: 30
 expression: m
 ---
 Manifest {
     package: Some(
         Package {
-            name: "foo",
+            name: "opt_version",
             edition: None,
-            version: Some(
-                Local(
-                    "1",
-                ),
-            ),
+            version: None,
             build: None,
             workspace: None,
             authors: None,
@@ -42,21 +39,40 @@ Manifest {
     workspace: None,
     dependencies: None,
     dev_dependencies: None,
-    build_dependencies: Some(
-        {
-            "lazy_static": Simple(
-                "1.4.0",
-            ),
-        },
-    ),
+    build_dependencies: None,
     target: None,
     features: None,
-    bin: None,
-    bench: None,
-    test: None,
-    example: None,
+    bin: Some(
+        [],
+    ),
+    bench: Some(
+        [],
+    ),
+    test: Some(
+        [],
+    ),
+    example: Some(
+        [],
+    ),
     patch: None,
-    lib: None,
+    lib: Some(
+        Product {
+            path: Some(
+                "lib.rs",
+            ),
+            name: None,
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ),
     profile: None,
     badges: None,
 }

--- a/tests/snapshots/parse__package_inheritance.snap
+++ b/tests/snapshots/parse__package_inheritance.snap
@@ -7,9 +7,11 @@ Manifest {
         Package {
             name: "bar",
             edition: None,
-            version: Inherited {
-                workspace: True,
-            },
+            version: Some(
+                Inherited {
+                    workspace: True,
+                },
+            ),
             build: None,
             workspace: None,
             authors: Some(

--- a/tests/snapshots/parse__proc_macro_casing-2.snap
+++ b/tests/snapshots/parse__proc_macro_casing-2.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__proc_macro_casing.snap
+++ b/tests/snapshots/parse__proc_macro_casing.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "foo",
             edition: None,
-            version: Local(
-                "1",
+            version: Some(
+                Local(
+                    "1",
+                ),
             ),
             build: None,
             workspace: None,

--- a/tests/snapshots/parse__workspace_dependency-2.snap
+++ b/tests/snapshots/parse__workspace_dependency-2.snap
@@ -7,8 +7,10 @@ Manifest {
         Package {
             name: "core",
             edition: None,
-            version: Local(
-                "0.1.0",
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
             ),
             build: None,
             workspace: None,


### PR DESCRIPTION
- a possibility from Cargo 1.75: https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-175-2023-12-28


*Description of changes:*

This would prepare for a subsequent fix in Cargo Chef of https://github.com/LukeMathWalker/cargo-chef/issues/265