### PR TITLE
Fix `authors` field in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 name = "cargo-manifest"
 version = "0.14.0"
-authors = ["Kornel <kornel@geekhood.net>, Luca Palmieri <rust@lpalmieri.com>"]
+authors = ["Kornel <kornel@geekhood.net>", "Luca Palmieri <rust@lpalmieri.com>"]
 description = "Helper crate to parse and manipulate manifests - `Cargo.toml` files."
 keywords = ["cargo", "metadata", "toml", "serde", "manifest"]
 categories = ["rust-patterns", "parser-implementations"]


### PR DESCRIPTION
The field is an array, so we should use it like that... :D