### PR TITLE
Adjust default `crate_type` for libraries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
                     name: Some(package.name.replace('-', "_")),
                     path: Some("src/lib.rs".to_string()),
                     edition,
-                    crate_type: Some(vec!["rlib".to_string()]),
+                    crate_type: Some(vec!["lib".to_string()]),
                     ..Product::default()
                 })
             }

--- a/tests/snapshots/parse__autolib.snap
+++ b/tests/snapshots/parse__autolib.snap
@@ -83,7 +83,7 @@ Manifest {
             required_features: [],
             crate_type: Some(
                 [
-                    "rlib",
+                    "lib",
                 ],
             ),
         },


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field specifies the default `crate-type` for libraries to be `lib` instead of `rlib`