### PR TITLE
Set default `crate_type` for binaries, examples, tests, and benchmarks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,7 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
                         name: Some(package.name.clone()),
                         path: Some("src/main.rs".to_string()),
                         edition,
+                        crate_type: Some(vec!["bin".to_string()]),
                         ..Product::default()
                     })
                 }
@@ -327,6 +328,7 @@ fn autoset<T>(package: &Package<T>, dir: &str, fs: &dyn AbstractFilesystem) -> V
                     name: Some(name.trim_end_matches(".rs").into()),
                     path: Some(rel_path),
                     edition,
+                    crate_type: Some(vec!["bin".to_string()]),
                     ..Product::default()
                 })
             } else if let Ok(sub) = fs.file_names_in(&rel_path) {
@@ -335,6 +337,7 @@ fn autoset<T>(package: &Package<T>, dir: &str, fs: &dyn AbstractFilesystem) -> V
                         name: Some(name.into()),
                         path: Some(rel_path + "/main.rs"),
                         edition,
+                        crate_type: Some(vec!["bin".to_string()]),
                         ..Product::default()
                     })
                 }

--- a/tests/snapshots/parse__autobin.snap
+++ b/tests/snapshots/parse__autobin.snap
@@ -74,7 +74,11 @@ Manifest {
                 E2018,
             ),
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     bench: [],


### PR DESCRIPTION
see https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field

If we set it for libraries (see https://github.com/LukeMathWalker/cargo-manifest/pull/36), then we should probably set it for other kinds of targets too.