### PR TITLE
Simplify `build.rs` lookup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,9 +302,7 @@ impl<Metadata: for<'a> Deserialize<'a>> Manifest<Metadata> {
             }
 
             if matches!(package.build, None | Some(StringOrBool::Bool(true)))
-                && fs
-                    .file_names_in(".")
-                    .map_or(false, |dir| dir.contains("build.rs"))
+                && fs.file_names_in(".")?.contains("build.rs")
             {
                 package.build = Some(StringOrBool::String("build.rs".to_string()));
             }


### PR DESCRIPTION
`file_names_in()` can fail in two relevant ways:

- If the requested folder does not exist it fails with a `NotFound` error. Since we are requesting `.` this cannot happen.
- If anything else IO-related fails we don't want to silently ignore it, instead we want to propagate that fact to the caller.