### PR TITLE
AbstractFilesystem: Add doc comments

### DIFF
--- a/src/afs.rs
+++ b/src/afs.rs
@@ -3,10 +3,20 @@ use std::fs::read_dir;
 use std::io;
 use std::path::Path;
 
+/// A trait for abstracting over filesystem operations.
+///
+/// This trait is primarily used for target auto-discovery in the
+/// [`complete_from_abstract_filesystem()`](crate::Manifest::complete_from_abstract_filesystem) method.
 pub trait AbstractFilesystem {
+    /// Returns a set of file and folder names in the given directory.
+    ///
+    /// This method should return a [std::io::ErrorKind::NotFound] error if the
+    /// directory does not exist.
     fn file_names_in(&self, rel_path: &str) -> io::Result<BTreeSet<Box<str>>>;
 }
 
+/// A [AbstractFilesystem] implementation that reads from the actual filesystem
+/// within the given root path.
 pub struct Filesystem<'a> {
     path: &'a Path,
 }


### PR DESCRIPTION
The `std::io::ErrorKind::NotFound` behavior wasn't properly described previously, so this PR adds a couple of doc comments to the trait and impl.