### PR TITLE
Update `insta` to v1.39.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ thiserror = "1.0.49"
 toml = { version = "0.8", features = ["preserve_order"] }
 
 [dev-dependencies]
-insta = "1.33.0"
+insta = "1.39.0"


### PR DESCRIPTION
This resolves the "yaml-rust is unmaintained" warning shown by cargo-deny.