### PR TITLE
Reimplement target auto-discovery

### DIFF
--- a/tests/autotarget.rs
+++ b/tests/autotarget.rs
@@ -97,13 +97,27 @@ fn test_full_example_with_declarations_2021() {
     insta::assert_debug_snapshot!(m);
     insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
 
-    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  <None>");
+    insta::assert_snapshot!(format_products(&m.bin), @r###"
+    named-executable  →  src/bin/named-executable.rs
+    another-executable  →  src/bin/another-executable.rs
+    multi-file-executable  →  src/bin/multi-file-executable/main.rs
+    test-package  →  src/main.rs
+    "###);
 
-    insta::assert_snapshot!(format_products(&m.example), @"simple  →  <None>");
+    insta::assert_snapshot!(format_products(&m.example), @r###"
+    simple  →  examples/simple.rs
+    multi-file-example  →  examples/multi-file-example/main.rs
+    "###);
 
-    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  <None>");
+    insta::assert_snapshot!(format_products(&m.test), @r###"
+    some-integration-tests  →  tests/some-integration-tests.rs
+    multi-file-test  →  tests/multi-file-test/main.rs
+    "###);
 
-    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  <None>");
+    insta::assert_snapshot!(format_products(&m.bench), @r###"
+    large-input  →  benches/large-input.rs
+    multi-file-bench  →  benches/multi-file-bench/main.rs
+    "###);
 }
 
 #[test]
@@ -129,10 +143,10 @@ fn test_full_example_with_declarations_2015() {
     let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
     insta::assert_debug_snapshot!(m);
     insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
-    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  <None>");
-    insta::assert_snapshot!(format_products(&m.example), @"simple  →  <None>");
-    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  <None>");
-    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  <None>");
+    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  src/bin/named-executable.rs");
+    insta::assert_snapshot!(format_products(&m.example), @"simple  →  examples/simple.rs");
+    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  tests/some-integration-tests.rs");
+    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  benches/large-input.rs");
 }
 
 #[test]

--- a/tests/autotarget.rs
+++ b/tests/autotarget.rs
@@ -1,0 +1,308 @@
+use cargo_manifest::{Manifest, Product};
+
+mod utils;
+
+const BASIC_MANIFEST: &str = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+"#;
+
+fn full_example_extra_files() -> Vec<&'static str> {
+    vec![
+        "benches/large-input.rs",
+        "benches/multi-file-bench/bench_module.rs",
+        "benches/multi-file-bench/main.rs",
+        "examples/multi-file-example/ex_module.rs",
+        "examples/multi-file-example/main.rs",
+        "examples/simple.rs",
+        "src/bin/another-executable.rs",
+        "src/bin/multi-file-executable/main.rs",
+        "src/bin/multi-file-executable/some_module.rs",
+        "src/bin/named-executable.rs",
+        "src/lib.rs",
+        "src/main.rs",
+        "tests/multi-file-test/main.rs",
+        "tests/multi-file-test/test_module.rs",
+        "tests/some-integration-tests.rs",
+    ]
+}
+
+fn format_products(products: &[Product]) -> String {
+    products
+        .iter()
+        .map(format_product)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn format_product(product: &Product) -> String {
+    let name = product.name.as_deref().unwrap_or("<None>");
+    let path = product.path.as_deref().unwrap_or("<None>");
+    format!("{name}  →  {path}")
+}
+
+#[test]
+fn test_full_example() {
+    let tempdir = utils::prepare(BASIC_MANIFEST, full_example_extra_files());
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_debug_snapshot!(m);
+    insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
+
+    insta::assert_snapshot!(format_products(&m.bin), @r###"
+    another-executable  →  src/bin/another-executable.rs
+    multi-file-executable  →  src/bin/multi-file-executable/main.rs
+    named-executable  →  src/bin/named-executable.rs
+    test-package  →  src/main.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.example), @r###"
+    multi-file-example  →  examples/multi-file-example/main.rs
+    simple  →  examples/simple.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.test), @r###"
+    multi-file-test  →  tests/multi-file-test/main.rs
+    some-integration-tests  →  tests/some-integration-tests.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.bench), @r###"
+    large-input  →  benches/large-input.rs
+    multi-file-bench  →  benches/multi-file-bench/main.rs
+    "###);
+}
+
+#[test]
+fn test_full_example_with_declarations_2021() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+    edition = "2021"
+
+    [[bin]]
+    name = "named-executable"
+
+    [[example]]
+    name = "simple"
+
+    [[test]]
+    name = "some-integration-tests"
+
+    [[bench]]
+    name = "large-input"
+    "#;
+    let tempdir = utils::prepare(manifest, full_example_extra_files());
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_debug_snapshot!(m);
+    insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
+
+    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  <None>");
+
+    insta::assert_snapshot!(format_products(&m.example), @"simple  →  <None>");
+
+    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  <None>");
+
+    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  <None>");
+}
+
+#[test]
+fn test_full_example_with_declarations_2015() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+
+    [[bin]]
+    name = "named-executable"
+
+    [[example]]
+    name = "simple"
+
+    [[test]]
+    name = "some-integration-tests"
+
+    [[bench]]
+    name = "large-input"
+    "#;
+    let tempdir = utils::prepare(manifest, full_example_extra_files());
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_debug_snapshot!(m);
+    insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
+    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  <None>");
+    insta::assert_snapshot!(format_products(&m.example), @"simple  →  <None>");
+    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  <None>");
+    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  <None>");
+}
+
+#[test]
+fn test_full_example_without_discovery() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+    edition = "2021"
+    autobins = false
+    autoexamples = false
+    autotests = false
+    autobenches = false
+    "#;
+    let tempdir = utils::prepare(manifest, full_example_extra_files());
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_debug_snapshot!(m);
+    insta::assert_snapshot!(format_products(&m.bin), @"");
+    insta::assert_snapshot!(format_products(&m.example), @"");
+    insta::assert_snapshot!(format_products(&m.test), @"");
+    insta::assert_snapshot!(format_products(&m.bench), @"");
+}
+
+/// Check that broken paths are handled without errors. It is up to the
+/// user to potentially turn this into a warning or error.
+#[test]
+fn test_declarations_with_broken_paths() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+
+    [[bin]]
+    name = "named-executable"
+    path = "named-executable.rs"
+
+    [[example]]
+    name = "simple"
+    path = "simple.rs"
+
+    [[test]]
+    name = "some-integration-tests"
+    path = "some-integration-tests.rs"
+
+    [[bench]]
+    name = "large-input"
+    path = "large-input.rs"
+    "#;
+    let tempdir = utils::prepare(manifest, vec![]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  named-executable.rs");
+    insta::assert_snapshot!(format_products(&m.example), @"simple  →  simple.rs");
+    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  some-integration-tests.rs");
+    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  large-input.rs");
+}
+
+/// Check that missing and broken paths are handled without errors. It is up
+/// to the user to potentially turn this into a warning or error.
+#[test]
+fn test_declarations_with_missing_and_broken_paths() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+
+    [[bin]]
+    name = "named-executable"
+
+    [[example]]
+    name = "simple"
+
+    [[test]]
+    name = "some-integration-tests"
+
+    [[bench]]
+    name = "large-input"
+    "#;
+    let tempdir = utils::prepare(manifest, vec![]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_snapshot!(format_products(&m.bin), @"named-executable  →  <None>");
+    insta::assert_snapshot!(format_products(&m.example), @"simple  →  <None>");
+    insta::assert_snapshot!(format_products(&m.test), @"some-integration-tests  →  <None>");
+    insta::assert_snapshot!(format_products(&m.bench), @"large-input  →  <None>");
+}
+
+/// Check that duplicate names are handled without errors. It is up to the
+/// user to potentially turn this into a warning or error.
+#[test]
+fn test_duplicate_names() {
+    let tempdir = utils::prepare(
+        BASIC_MANIFEST,
+        vec![
+            "benches/large-input.rs",
+            "benches/large-input/main.rs",
+            "examples/simple.rs",
+            "examples/simple/main.rs",
+            "src/bin/test-package.rs",
+            "src/bin/test-package/main.rs",
+            "src/main.rs",
+            "tests/some-tests.rs",
+            "tests/some-tests/main.rs",
+        ],
+    );
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+
+    insta::assert_snapshot!(format_products(&m.bin), @r###"
+    test-package  →  src/bin/test-package/main.rs
+    test-package  →  src/bin/test-package.rs
+    test-package  →  src/main.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.example), @r###"
+    simple  →  examples/simple/main.rs
+    simple  →  examples/simple.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.test), @r###"
+    some-tests  →  tests/some-tests/main.rs
+    some-tests  →  tests/some-tests.rs
+    "###);
+
+    insta::assert_snapshot!(format_products(&m.bench), @r###"
+    large-input  →  benches/large-input/main.rs
+    large-input  →  benches/large-input.rs
+    "###);
+}
+
+/// Check that missing names are handled without errors. It is up to the
+/// user to potentially turn this into a warning or error.
+#[test]
+fn test_missing_names() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+
+    [[bin]]
+    path = "named-executable.rs"
+
+    [[example]]
+    path = "simple.rs"
+
+    [[test]]
+    path = "some-integration-tests.rs"
+
+    [[bench]]
+    path = "large-input.rs"
+    "#;
+    let tempdir = utils::prepare(manifest, vec![]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_snapshot!(format_products(&m.bin), @"<None>  →  named-executable.rs");
+    insta::assert_snapshot!(format_products(&m.example), @"<None>  →  simple.rs");
+    insta::assert_snapshot!(format_products(&m.test), @"<None>  →  some-integration-tests.rs");
+    insta::assert_snapshot!(format_products(&m.bench), @"<None>  →  large-input.rs");
+}
+
+/// see https://doc.rust-lang.org/cargo/reference/cargo-targets.html#target-auto-discovery
+#[test]
+fn test_bin_module_example() {
+    let manifest = r#"
+    [package]
+    name = "test-package"
+    version = "0.1.0"
+    autobins = false
+    "#;
+    let tempdir = utils::prepare(manifest, vec!["src/lib.rs", "src/bin/mod.rs"]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+    insta::assert_snapshot!(format_product(&m.lib.unwrap()), @"test_package  →  src/lib.rs");
+    insta::assert_snapshot!(format_products(&m.bin), @"");
+    insta::assert_snapshot!(format_products(&m.example), @"");
+    insta::assert_snapshot!(format_products(&m.test), @"");
+    insta::assert_snapshot!(format_products(&m.bench), @"");
+}

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -33,23 +33,6 @@ fn opt_version() {
 }
 
 #[test]
-fn autobin() {
-    let manifest = r#"
-    [package]
-    name = "auto-bin"
-    version = "0.1.0"
-    publish = false
-    edition = "2018"
-
-    [badges]
-    travis-ci = { repository = "…" }
-    "#;
-    let tempdir = utils::prepare(manifest, vec!["src/main.rs"]);
-    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
-    insta::assert_debug_snapshot!(m);
-}
-
-#[test]
 fn autobuild() {
     let manifest = r#"
     [package]

--- a/tests/snapshots/autotarget__full_example.snap
+++ b/tests/snapshots/autotarget__full_example.snap
@@ -1,0 +1,303 @@
+---
+source: tests/autotarget.rs
+expression: m
+---
+Manifest {
+    package: Some(
+        Package {
+            name: "test-package",
+            edition: None,
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
+            ),
+            build: None,
+            workspace: None,
+            authors: None,
+            links: None,
+            description: None,
+            homepage: None,
+            documentation: None,
+            readme: None,
+            keywords: None,
+            categories: None,
+            license: None,
+            license_file: None,
+            repository: None,
+            metadata: None,
+            rust_version: None,
+            exclude: None,
+            include: None,
+            default_run: None,
+            autobins: None,
+            autoexamples: None,
+            autotests: None,
+            autobenches: None,
+            publish: None,
+            resolver: None,
+        },
+    ),
+    cargo_features: None,
+    workspace: None,
+    dependencies: None,
+    dev_dependencies: None,
+    build_dependencies: None,
+    target: None,
+    features: None,
+    bin: [
+        Product {
+            path: Some(
+                "src/bin/another-executable.rs",
+            ),
+            name: Some(
+                "another-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/bin/multi-file-executable/main.rs",
+            ),
+            name: Some(
+                "multi-file-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/bin/named-executable.rs",
+            ),
+            name: Some(
+                "named-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/main.rs",
+            ),
+            name: Some(
+                "test-package",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+    ],
+    bench: [
+        Product {
+            path: Some(
+                "benches/large-input.rs",
+            ),
+            name: Some(
+                "large-input",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "benches/multi-file-bench/main.rs",
+            ),
+            name: Some(
+                "multi-file-bench",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+    ],
+    test: [
+        Product {
+            path: Some(
+                "tests/multi-file-test/main.rs",
+            ),
+            name: Some(
+                "multi-file-test",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "tests/some-integration-tests.rs",
+            ),
+            name: Some(
+                "some-integration-tests",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+    ],
+    example: [
+        Product {
+            path: Some(
+                "examples/multi-file-example/main.rs",
+            ),
+            name: Some(
+                "multi-file-example",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "examples/simple.rs",
+            ),
+            name: Some(
+                "simple",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+    ],
+    patch: None,
+    lib: Some(
+        Product {
+            path: Some(
+                "src/lib.rs",
+            ),
+            name: Some(
+                "test_package",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "lib",
+                ],
+            ),
+        },
+    ),
+    profile: None,
+    badges: None,
+}

--- a/tests/snapshots/autotarget__full_example_with_declarations_2015.snap
+++ b/tests/snapshots/autotarget__full_example_with_declarations_2015.snap
@@ -1,0 +1,147 @@
+---
+source: tests/autotarget.rs
+expression: m
+---
+Manifest {
+    package: Some(
+        Package {
+            name: "test-package",
+            edition: None,
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
+            ),
+            build: None,
+            workspace: None,
+            authors: None,
+            links: None,
+            description: None,
+            homepage: None,
+            documentation: None,
+            readme: None,
+            keywords: None,
+            categories: None,
+            license: None,
+            license_file: None,
+            repository: None,
+            metadata: None,
+            rust_version: None,
+            exclude: None,
+            include: None,
+            default_run: None,
+            autobins: None,
+            autoexamples: None,
+            autotests: None,
+            autobenches: None,
+            publish: None,
+            resolver: None,
+        },
+    ),
+    cargo_features: None,
+    workspace: None,
+    dependencies: None,
+    dev_dependencies: None,
+    build_dependencies: None,
+    target: None,
+    features: None,
+    bin: [
+        Product {
+            path: None,
+            name: Some(
+                "named-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    bench: [
+        Product {
+            path: None,
+            name: Some(
+                "large-input",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    test: [
+        Product {
+            path: None,
+            name: Some(
+                "some-integration-tests",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    example: [
+        Product {
+            path: None,
+            name: Some(
+                "simple",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    patch: None,
+    lib: Some(
+        Product {
+            path: Some(
+                "src/lib.rs",
+            ),
+            name: Some(
+                "test_package",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: Some(
+                [
+                    "lib",
+                ],
+            ),
+        },
+    ),
+    profile: None,
+    badges: None,
+}

--- a/tests/snapshots/autotarget__full_example_with_declarations_2015.snap
+++ b/tests/snapshots/autotarget__full_example_with_declarations_2015.snap
@@ -47,7 +47,9 @@ Manifest {
     features: None,
     bin: [
         Product {
-            path: None,
+            path: Some(
+                "src/bin/named-executable.rs",
+            ),
             name: Some(
                 "named-executable",
             ),
@@ -60,12 +62,18 @@ Manifest {
             harness: true,
             edition: None,
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     bench: [
         Product {
-            path: None,
+            path: Some(
+                "benches/large-input.rs",
+            ),
             name: Some(
                 "large-input",
             ),
@@ -78,12 +86,18 @@ Manifest {
             harness: true,
             edition: None,
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     test: [
         Product {
-            path: None,
+            path: Some(
+                "tests/some-integration-tests.rs",
+            ),
             name: Some(
                 "some-integration-tests",
             ),
@@ -96,12 +110,18 @@ Manifest {
             harness: true,
             edition: None,
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     example: [
         Product {
-            path: None,
+            path: Some(
+                "examples/simple.rs",
+            ),
             name: Some(
                 "simple",
             ),
@@ -114,7 +134,11 @@ Manifest {
             harness: true,
             edition: None,
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     patch: None,

--- a/tests/snapshots/autotarget__full_example_with_declarations_2021.snap
+++ b/tests/snapshots/autotarget__full_example_with_declarations_2021.snap
@@ -1,0 +1,153 @@
+---
+source: tests/autotarget.rs
+expression: m
+---
+Manifest {
+    package: Some(
+        Package {
+            name: "test-package",
+            edition: Some(
+                Local(
+                    E2021,
+                ),
+            ),
+            version: Some(
+                Local(
+                    "0.1.0",
+                ),
+            ),
+            build: None,
+            workspace: None,
+            authors: None,
+            links: None,
+            description: None,
+            homepage: None,
+            documentation: None,
+            readme: None,
+            keywords: None,
+            categories: None,
+            license: None,
+            license_file: None,
+            repository: None,
+            metadata: None,
+            rust_version: None,
+            exclude: None,
+            include: None,
+            default_run: None,
+            autobins: None,
+            autoexamples: None,
+            autotests: None,
+            autobenches: None,
+            publish: None,
+            resolver: None,
+        },
+    ),
+    cargo_features: None,
+    workspace: None,
+    dependencies: None,
+    dev_dependencies: None,
+    build_dependencies: None,
+    target: None,
+    features: None,
+    bin: [
+        Product {
+            path: None,
+            name: Some(
+                "named-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    bench: [
+        Product {
+            path: None,
+            name: Some(
+                "large-input",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    test: [
+        Product {
+            path: None,
+            name: Some(
+                "some-integration-tests",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    example: [
+        Product {
+            path: None,
+            name: Some(
+                "simple",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: None,
+            required_features: [],
+            crate_type: None,
+        },
+    ],
+    patch: None,
+    lib: Some(
+        Product {
+            path: Some(
+                "src/lib.rs",
+            ),
+            name: Some(
+                "test_package",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "lib",
+                ],
+            ),
+        },
+    ),
+    profile: None,
+    badges: None,
+}

--- a/tests/snapshots/autotarget__full_example_with_declarations_2021.snap
+++ b/tests/snapshots/autotarget__full_example_with_declarations_2021.snap
@@ -51,7 +51,9 @@ Manifest {
     features: None,
     bin: [
         Product {
-            path: None,
+            path: Some(
+                "src/bin/named-executable.rs",
+            ),
             name: Some(
                 "named-executable",
             ),
@@ -62,14 +64,94 @@ Manifest {
             plugin: false,
             proc_macro: false,
             harness: true,
-            edition: None,
+            edition: Some(
+                E2021,
+            ),
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/bin/another-executable.rs",
+            ),
+            name: Some(
+                "another-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/bin/multi-file-executable/main.rs",
+            ),
+            name: Some(
+                "multi-file-executable",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "src/main.rs",
+            ),
+            name: Some(
+                "test-package",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     bench: [
         Product {
-            path: None,
+            path: Some(
+                "benches/large-input.rs",
+            ),
             name: Some(
                 "large-input",
             ),
@@ -80,14 +162,46 @@ Manifest {
             plugin: false,
             proc_macro: false,
             harness: true,
-            edition: None,
+            edition: Some(
+                E2021,
+            ),
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "benches/multi-file-bench/main.rs",
+            ),
+            name: Some(
+                "multi-file-bench",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     test: [
         Product {
-            path: None,
+            path: Some(
+                "tests/some-integration-tests.rs",
+            ),
             name: Some(
                 "some-integration-tests",
             ),
@@ -98,14 +212,46 @@ Manifest {
             plugin: false,
             proc_macro: false,
             harness: true,
-            edition: None,
+            edition: Some(
+                E2021,
+            ),
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "tests/multi-file-test/main.rs",
+            ),
+            name: Some(
+                "multi-file-test",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     example: [
         Product {
-            path: None,
+            path: Some(
+                "examples/simple.rs",
+            ),
             name: Some(
                 "simple",
             ),
@@ -116,9 +262,39 @@ Manifest {
             plugin: false,
             proc_macro: false,
             harness: true,
-            edition: None,
+            edition: Some(
+                E2021,
+            ),
             required_features: [],
-            crate_type: None,
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
+        },
+        Product {
+            path: Some(
+                "examples/multi-file-example/main.rs",
+            ),
+            name: Some(
+                "multi-file-example",
+            ),
+            test: true,
+            doctest: true,
+            bench: true,
+            doc: true,
+            plugin: false,
+            proc_macro: false,
+            harness: true,
+            edition: Some(
+                E2021,
+            ),
+            required_features: [],
+            crate_type: Some(
+                [
+                    "bin",
+                ],
+            ),
         },
     ],
     patch: None,

--- a/tests/snapshots/autotarget__full_example_without_discovery.snap
+++ b/tests/snapshots/autotarget__full_example_without_discovery.snap
@@ -1,14 +1,14 @@
 ---
-source: tests/parse.rs
+source: tests/autotarget.rs
 expression: m
 ---
 Manifest {
     package: Some(
         Package {
-            name: "auto-bin",
+            name: "test-package",
             edition: Some(
                 Local(
-                    E2018,
+                    E2021,
                 ),
             ),
             version: Some(
@@ -34,17 +34,19 @@ Manifest {
             exclude: None,
             include: None,
             default_run: None,
-            autobins: None,
-            autoexamples: None,
-            autotests: None,
-            autobenches: None,
-            publish: Some(
-                Local(
-                    Flag(
-                        false,
-                    ),
-                ),
+            autobins: Some(
+                false,
             ),
+            autoexamples: Some(
+                false,
+            ),
+            autotests: Some(
+                false,
+            ),
+            autobenches: Some(
+                false,
+            ),
+            publish: None,
             resolver: None,
         },
     ),
@@ -55,13 +57,18 @@ Manifest {
     build_dependencies: None,
     target: None,
     features: None,
-    bin: [
+    bin: [],
+    bench: [],
+    test: [],
+    example: [],
+    patch: None,
+    lib: Some(
         Product {
             path: Some(
-                "src/main.rs",
+                "src/lib.rs",
             ),
             name: Some(
-                "auto-bin",
+                "test_package",
             ),
             test: true,
             doctest: true,
@@ -71,43 +78,16 @@ Manifest {
             proc_macro: false,
             harness: true,
             edition: Some(
-                E2018,
+                E2021,
             ),
             required_features: [],
             crate_type: Some(
                 [
-                    "bin",
+                    "lib",
                 ],
             ),
         },
-    ],
-    bench: [],
-    test: [],
-    example: [],
-    patch: None,
-    lib: None,
-    profile: None,
-    badges: Some(
-        Badges {
-            appveyor: None,
-            circle_ci: None,
-            gitlab: None,
-            travis_ci: Some(
-                Badge {
-                    repository: "…",
-                    branch: "master",
-                    service: None,
-                    id: None,
-                    project_name: None,
-                },
-            ),
-            codecov: None,
-            coveralls: None,
-            is_it_maintained_issue_resolution: None,
-            is_it_maintained_open_issues: None,
-            maintenance: Maintenance {
-                status: None,
-            },
-        },
     ),
+    profile: None,
+    badges: None,
 }


### PR DESCRIPTION
This fixes the merging behavior of the auto-discovery code. Previously an explicit `[[bin]]` would turn off the auto-discovery unconditionally, but:

- in the 2018 edition the behavior was changed so that only `autobins = false` would disable the auto-discovery
- the auto-discovery information should still be used to fill in the `path` values

This PR changes the behavior to act accordingly. `cargo` shows errors in a couple of more situations (see tests), but the new implementation explicitly does not treat these as hard errors to be able to ignore broken target declarations in existing crates and turn them into warnings instead.

Resolves #35

/cc @kornelski