### PR TITLE
Implement legacy library discovery fallback

### DIFF
--- a/tests/autolib.rs
+++ b/tests/autolib.rs
@@ -88,3 +88,58 @@ fn test_other_override() {
 
     insta::assert_debug_snapshot!(lib);
 }
+
+#[test]
+fn test_legacy_lib_with_name() {
+    let manifest = r#"
+    [package]
+    name = "auto-lib"
+    version = "0.1.0"
+
+    [lib]
+    name = "foo"
+    "#;
+    let tempdir = utils::prepare(manifest, vec!["src/foo.rs"]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+
+    let lib = m.lib.unwrap();
+    assert_eq!(lib.path.as_deref(), Some("src/foo.rs"));
+    assert_eq!(lib.name.as_deref(), Some("foo"));
+
+    insta::assert_debug_snapshot!(lib);
+}
+
+#[test]
+fn test_legacy_lib_without_name() {
+    let manifest = r#"
+    [package]
+    name = "auto-lib"
+    version = "0.1.0"
+
+    [lib]
+    "#;
+    let tempdir = utils::prepare(manifest, vec!["src/auto-lib.rs"]);
+    let m = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap();
+
+    let lib = m.lib.unwrap();
+    assert_eq!(lib.path.as_deref(), Some("src/auto-lib.rs"));
+    assert_eq!(lib.name.as_deref(), Some("auto_lib"));
+
+    insta::assert_debug_snapshot!(lib);
+}
+
+#[test]
+fn test_legacy_lib_with_new_edition() {
+    let manifest = r#"
+    [package]
+    name = "auto-lib"
+    version = "0.1.0"
+    edition = "2018"
+
+    [lib]
+    name = "foo"
+    "#;
+    let tempdir = utils::prepare(manifest, vec!["src/foo.rs"]);
+    let error = Manifest::from_path(tempdir.path().join("Cargo.toml")).unwrap_err();
+    insta::assert_snapshot!(error, @"can't find library, rename file to `src/lib.rs` or specify lib.path");
+}

--- a/tests/snapshots/autolib__legacy_lib_with_name.snap
+++ b/tests/snapshots/autolib__legacy_lib_with_name.snap
@@ -1,0 +1,26 @@
+---
+source: tests/autolib.rs
+expression: lib
+---
+Product {
+    path: Some(
+        "src/foo.rs",
+    ),
+    name: Some(
+        "foo",
+    ),
+    test: true,
+    doctest: true,
+    bench: true,
+    doc: true,
+    plugin: false,
+    proc_macro: false,
+    harness: true,
+    edition: None,
+    required_features: [],
+    crate_type: Some(
+        [
+            "lib",
+        ],
+    ),
+}

--- a/tests/snapshots/autolib__legacy_lib_with_new_edition.snap
+++ b/tests/snapshots/autolib__legacy_lib_with_new_edition.snap
@@ -1,0 +1,5 @@
+---
+source: tests/autolib.rs
+expression: error
+---
+can't find library, rename file to `src/lib.rs` or specify lib.path

--- a/tests/snapshots/autolib__legacy_lib_without_name.snap
+++ b/tests/snapshots/autolib__legacy_lib_without_name.snap
@@ -1,0 +1,26 @@
+---
+source: tests/autolib.rs
+expression: lib
+---
+Product {
+    path: Some(
+        "src/auto-lib.rs",
+    ),
+    name: Some(
+        "auto_lib",
+    ),
+    test: true,
+    doctest: true,
+    bench: true,
+    doc: true,
+    plugin: false,
+    proc_macro: false,
+    harness: true,
+    edition: None,
+    required_features: [],
+    crate_type: Some(
+        [
+            "lib",
+        ],
+    ),
+}


### PR DESCRIPTION
In the 2015 Edition it was possible to use `src/{lib_name}.rs` instead of `src/lib.rs`. cargo would warn about it, but still accept this. crates.io currently contains about 450 crate files that use this pattern.