### PR TITLE
Add release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,109 @@
+# Changelog
+
+## v0.15.0 (2024-06-29)
+
+### :rocket: Enhancements
+
+- [#32](https://github.com/LukeMathWalker/cargo-manifest/pull/32) Simplify `Option<Vec<Product>>` to `Vec<Product>` ([@Turbo87](https://github/Turbo87))
+- [#36](https://github.com/LukeMathWalker/cargo-manifest/pull/36) Adjust default `crate_type` for libraries ([@Turbo87](https://github/Turbo87))
+- [#37](https://github.com/LukeMathWalker/cargo-manifest/pull/37) Set default `crate_type` for binaries, examples, tests, and benchmarks ([@Turbo87](https://github/Turbo87))
+- [#38](https://github.com/LukeMathWalker/cargo-manifest/pull/38) Fill explicit `lib` declaration with default values ([@Turbo87](https://github/Turbo87))
+- [#40](https://github.com/LukeMathWalker/cargo-manifest/pull/40) AbstractFilesystem: Add doc comments ([@Turbo87](https://github/Turbo87))
+- [#41](https://github.com/LukeMathWalker/cargo-manifest/pull/41) Change `autobins` and friends to `Option<bool>` ([@Turbo87](https://github/Turbo87))
+- [#43](https://github.com/LukeMathWalker/cargo-manifest/pull/43) Add doc comments to `Package::auto*` fields ([@Turbo87](https://github/Turbo87))
+- [#47](https://github.com/LukeMathWalker/cargo-manifest/pull/47) Implement `Package::version()` fn ([@Turbo87](https://github/Turbo87))
+
+### :bug: Bugfixes
+
+- [#48](https://github.com/LukeMathWalker/cargo-manifest/pull/48) Reimplement target auto-discovery ([@Turbo87](https://github/Turbo87))
+
+## v0.14.0 (2024-03-29)
+
+### :rocket: Enhancements
+
+- [#30](https://github.com/LukeMathWalker/cargo-manifest/pull/30) Package version can now be optional ([@markdingram](https://github/markdingram))
+
+## v0.12.1 (2023-10-14)
+
+### :rocket: Enhancements
+
+- [#27](https://github.com/LukeMathWalker/cargo-manifest/pull/27) Dependency: Implement `simplify()` fn ([@Turbo87](https://github/Turbo87))
+
+## v0.12.0 (2023-09-28)
+
+### :rocket: Enhancements
+
+- [#24](https://github.com/LukeMathWalker/cargo-manifest/pull/24) Dependency: Add `Inherited` variant ([@Turbo87](https://github/Turbo87))
+
+## v0.11.1 (2023-09-18)
+
+### :rocket: Enhancements
+
+- [#21](https://github.com/LukeMathWalker/cargo-manifest/pull/21) Skip serialization for `bool` fields if the value matches the default value ([@Turbo87](https://github/Turbo87))
+- [#22](https://github.com/LukeMathWalker/cargo-manifest/pull/22) Make `Manifest` and `Package` easier to instantiate ([@Turbo87](https://github/Turbo87))
+
+### :bug: Bugfixes
+
+- [#20](https://github.com/LukeMathWalker/cargo-manifest/pull/20) Package: Fix `default-run` naming ([@Turbo87](https://github/Turbo87))
+
+## v0.11.0 (2023-09-11)
+
+### :rocket: Enhancements
+
+- [#19](https://github.com/LukeMathWalker/cargo-manifest/pull/19) Add split-debuginfo to cargo profiles ([@mladedav](https://github/mladedav))
+
+## v0.10.0 (2023-08-31)
+
+### :rocket: Enhancements
+
+- [#17](https://github.com/LukeMathWalker/cargo-manifest/pull/17) MaybeInherited: Implement `as_ref()` and `local()` fns ([@Turbo87](https://github/Turbo87))
+- [#18](https://github.com/LukeMathWalker/cargo-manifest/pull/18) Change `build` field to `Option<StringOrBool>` ([@Turbo87](https://github/Turbo87))
+
+## v0.9.0 (2023-05-20)
+
+### :rocket: Enhancements
+
+- [#16](https://github.com/LukeMathWalker/cargo-manifest/pull/16) Copy strip settings from upstream ([@divergentdave](https://github/divergentdave))
+
+## v0.8.0 (2023-04-06)
+
+## v0.7.1 (2022-12-15)
+
+## v0.7.0 (2022-12-13)
+
+## v0.6.0 (2022-12-10)
+
+## v0.5.0 (2022-12-07)
+
+### :rocket: Enhancements
+
+- [#14](https://github.com/LukeMathWalker/cargo-manifest/pull/14) Fix MaybeInherited repository issue. ([@dessalines](https://github/dessalines))
+
+## v0.4.0 (2022-09-23)
+
+## v0.3.0 (2022-08-24)
+
+### :rocket: Enhancements
+
+- [#13](https://github.com/LukeMathWalker/cargo-manifest/pull/13) [Breaking] Refine serialization 
+
+## v0.2.9 (2022-08-19)
+
+## v0.2.8 (2022-07-01)
+
+### :rocket: Enhancements
+
+- [#12](https://github.com/LukeMathWalker/cargo-manifest/pull/12) Add support for the inherits field. 
+
+## v0.2.7 (2022-06-26)
+
+## v0.2.6 (2021-09-03)
+
+## v0.2.5 (2021-09-02)
+
+## v0.2.4 (2021-04-21)
+
+## v0.2.3 (2021-01-19)
+
+## v0.2.2 (2021-01-02)
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ toml = { version = "0.8", features = ["preserve_order"] }
 [dev-dependencies]
 insta = "1.39.0"
 tempfile = "3.10.1"
+
+[package.metadata.release]
+pre-release-hook = ["git", "cliff", "-o", "--tag", "{{version}}"]

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,70 @@
+# git-cliff ~ default configuration file
+# https://git-cliff.org/docs/configuration
+
+[git]
+conventional_commits = false
+topo_order = true
+
+[remote.github]
+owner = "LukeMathWalker"
+repo = "cargo-manifest"
+# token = "from GITHUB_TOKEN env var"
+
+[changelog]
+header = "# Changelog\n\n"
+
+body = """
+{% if version %}\
+    ## v{{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%Y-%m-%d") }})\n
+{% else %}\
+    ## [unreleased]\n
+{% endif %}\
+
+{% set_global breaking = [] %}\
+{% set_global enhancements = [] %}\
+{% set_global bugs = [] %}\
+{% set_global docs = [] %}\
+{% set_global internal = [] %}\
+{%- for pr_number, commits in commits | group_by(attribute="github.pr_number") -%}
+    {% set commit = commits | first %}
+    {%- if commit.github.pr_labels is containing("breaking") -%}
+        {% set_global breaking = breaking | concat(with=commit) %}
+    {%- elif commit.github.pr_labels is containing("enhancement") -%}
+        {% set_global enhancements = enhancements | concat(with=commit) %}
+    {%- elif commit.github.pr_labels is containing("bug") -%}
+        {% set_global bugs = bugs | concat(with=commit) %}
+    {%- elif commit.github.pr_labels is containing("documentation") -%}
+        {% set_global docs = docs | concat(with=commit) %}
+    {%- elif commit.github.pr_labels is containing("internal") -%}
+        {% set_global internal = internal | concat(with=commit) %}
+    {%- endif -%}
+{%- endfor -%}
+
+{{ self::section(title=":boom: Breaking Change", commits=breaking) }}\
+{{ self::section(title=":rocket: Enhancements", commits=enhancements) }}\
+{{ self::section(title=":bug: Bugfixes", commits=bugs) }}\
+{{ self::section(title=":memo: Documentation", commits=docs) }}\
+{{ self::section(title=":house: Internal", commits=internal) }}\
+
+{% macro section(title, commits) -%}
+    {%- if commits | length > 0 -%}
+        ### {{ title }}
+
+        {% for commit in commits -%}
+            {{ self::commit(commit=commit) }}
+        {%- endfor %}
+    {% endif -%}
+{%- endmacro -%}
+
+{%- macro commit(commit) -%}
+    - [#{{ commit.github.pr_number }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/pull/{{ commit.github.pr_number }}) \
+    {{ commit.github.pr_title }} \
+    {% if commit.github.username -%}
+        ([@{{ commit.github.username }}](https://github/{{ commit.github.username }}))
+    {%- endif %}
+{% endmacro -%}
+
+{%- macro remote_url() -%}
+    https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+"""


### PR DESCRIPTION
This adds a changelog generated via https://git-cliff.org/

The changelog contains all pull requests labeled with `breaking`, `enhancement`, `bug`, `documentation` or `internal` and shows them in their corresponding groups.

The file can be regenerated via `git cliff -o`, assuming that a `GITHUB_TOKEN` environment variable has been set to allow unthrottled GitHub API access.