### PR TITLE
Use `README.md` as module doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Usage
 ------------------------------------------------------------------------------
 
 ```rust
+use cargo_manifest::Manifest;
+
 fn main() {
     let manifest = Manifest::from_path("Cargo.toml").unwrap();
 }

--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ Usage
 ```rust
 use cargo_manifest::Manifest;
 
-fn main() {
-    let manifest = Manifest::from_path("Cargo.toml").unwrap();
-}
+let manifest = Manifest::from_path("Cargo.toml").unwrap();
 ```
 
 see [docs.rs](https://docs.rs/cargo-manifest) for more information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(clippy::large_enum_variant)]
-//! This crate defines `struct`s that can be deserialized with Serde
-//! to load and inspect `Cargo.toml` metadata.
-//!
-//! See `Manifest::from_slice`.
+#![doc = include_str!("../README.md")]
+
 use serde::Deserializer;
 use serde::{Deserialize, Serialize, Serializer};
 use std::collections::BTreeMap;


### PR DESCRIPTION
<img width="1032" alt="Bildschirmfoto 2024-09-05 um 12 36 13" src="https://github.com/user-attachments/assets/26243992-55a8-4e09-bd33-182d3ccd208f">

unfortunately the "note" block isn't rendered by rustdoc, but that could be addressed in a dedicated PR if anyone is annoyed enough by it :)