### PR TITLE
toml: disable the unused `display` Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,15 @@ path = "src/lib.rs"
 [dependencies]
 serde = { version = "1.0.114", features = ["derive"] }
 thiserror = "1.0.49"
-toml = { version = "0.8", features = ["preserve_order"] }
+toml = { version = "0.8", default-features = false, features = [
+  "parse",
+  "preserve_order",
+] }
 
 [dev-dependencies]
 insta = "1.39.0"
 tempfile = "3.10.1"
+toml = { version = "0.8", default-features = false, features = ["display"] }
 
 [package.metadata.release]
 pre-release-hook = ["git", "cliff", "-o", "--tag", "{{version}}"]


### PR DESCRIPTION
Thank you for your work on this crate! I particularly appreciate the ability to specify a custom `Metadata` type when reading a manifest.
This PR proposes to disable the unused `display` Cargo feature to slightly reduce compile time for users (which may be useful when using `cargo-manifest` from a proc-macro in the compilation critical path), see the commit message below.

---

The `display` Cargo feature of the `toml` dependency is only used for tests, so we disable it to reduce the effective size for users, and enable it only for tests.
For reference, the default features of `toml` are `display` and `parse`.