### PR TITLE
Support `package.resolver = "3"`, as shipped in Rust 1.84.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,6 +1265,8 @@ pub enum Resolver {
     V1,
     #[serde(rename = "2")]
     V2,
+    #[serde(rename = "3")]
+    V3,
 }
 
 impl Default for Resolver {


### PR DESCRIPTION
Fixes #63.