### PR TITLE
Fix impl Default for Manifest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub struct Manifest<PackageMetadata = Value, WorkspaceMetadata = Value> {
     pub badges: Option<Badges>,
 }
 
-impl<Metadata> Default for Manifest<Metadata> {
+impl<PackageMetadata, WorkspaceMetadata> Default for Manifest<PackageMetadata, WorkspaceMetadata> {
     #[allow(deprecated)]
     fn default() -> Self {
         Self {

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -2,8 +2,8 @@ use cargo_manifest::{Manifest, Package};
 
 #[test]
 fn basic() {
-    let manifest = Manifest {
-        package: Some(Package::<()>::new("foo".into(), "1.0.0".into())),
+    let manifest: Manifest<(), ()> = Manifest {
+        package: Some(Package::new("foo".into(), "1.0.0".into())),
         ..Default::default()
     };
 


### PR DESCRIPTION
The current Default implementation is limited to `Manifest<_, Value>`, because the impl of `Default` only specifies the first type parameter. This PR aims to fix that